### PR TITLE
fix(user uuid): Try to fix this bug

### DIFF
--- a/wp-content/themes/t-vkrz-3/function/meca/begin_t.php
+++ b/wp-content/themes/t-vkrz-3/function/meca/begin_t.php
@@ -74,6 +74,13 @@ function begin_t($id_top, $uuiduser, $typetop){
     update_field('timeline_5', 0, $id_ranking);
     update_field('utm_campaign_r', $utm, $id_ranking);
 
+    if (is_user_logged_in()) {
+        global $user_id;
+        if ($user_id && !get_field('uuiduser_user', 'user_'.$user_id) && $uuiduser) {
+            update_field('uuiduser_user', $uuiduser, 'user_' . $user_id);
+        }
+    }
+
     return $id_ranking;
 
 }

--- a/wp-content/themes/t-vkrz-3/function/meca/deal-uuiduser.php
+++ b/wp-content/themes/t-vkrz-3/function/meca/deal-uuiduser.php
@@ -5,28 +5,20 @@ function deal_uuiduser(){
 
         global $user_id;
 
-        $uuiuser        = get_field('uuiduser_user', 'user_'.$user_id);
+        $uuiuser = get_field('uuiduser_user', 'user_'.$user_id);
 
-        if(isset($uuiuser) && $uuiuser != ""){
-
+        if (isset($uuiuser) && !empty($uuiuser)) {
             $result = $uuiuser;
-
-        }
-        else{
-
-            if(isset($_COOKIE["vainkeurz_user_id"]) && $_COOKIE["vainkeurz_user_id"] != ""){
+        } else {
+            if (isset($_COOKIE["vainkeurz_user_id"]) && $_COOKIE["vainkeurz_user_id"] != "") {
                 $result = $_COOKIE["vainkeurz_user_id"];
-            }
-            else{
+            } else {
                 $result = uniqidReal();
             }
 
             update_field('uuiduser_user', $result, 'user_' . $user_id);
-
         }
-
-    }
-    else{
+    } else {
 
         if(isset($_COOKIE["vainkeurz_user_id"]) && $_COOKIE["vainkeurz_user_id"] != ""){
             $result = $_COOKIE["vainkeurz_user_id"];
@@ -37,8 +29,9 @@ function deal_uuiduser(){
 
     }
 
-    setcookie("vainkeurz_user_id", $result, time()+31556926, "/");
+    if (!isset($_COOKIE['vainkeurz_user_id']) || empty($_COOKIE["vainkeurz_user_id"])) {
+        setcookie("vainkeurz_user_id", $result, time()+31556926, "/");
+    }
 
     return $result;
-
 }

--- a/wp-content/themes/t-vkrz-3/function/webhooks/new_vainkeur.php
+++ b/wp-content/themes/t-vkrz-3/function/webhooks/new_vainkeur.php
@@ -1,9 +1,15 @@
 <?php
-add_action('user_register', 'new_vainkeur', 10, 1);
+add_action('user_register', 'new_vainkeur', 20, 1);
 function new_vainkeur($user_id){
 
     $new_user_infos = get_user_infos($_COOKIE["vainkeurz_user_id"]);
     $user_url       = get_author_posts_url($user_id);
+
+    /*
+    // Logguer l'erreur du user sans uuid
+    if (!isset($_COOKIE['vainkeurz_user_id']) || empty($_COOKIE["vainkeurz_user_id"])){
+        // TODO: Logguer une erreur avec des infos (plugin d'inscription, email, uuid, user_id, navigateur, version, os, est-ce qu'il rentre bien dans les fonctions, est-ce que les fonctions s'execute intégrallement)
+    }
 
     $url    = "https://hook.integromat.com/q6wsg4hejd3k3mveq9nn6ycvwgc5y7kp";
     $args   = array(
@@ -21,67 +27,72 @@ function new_vainkeur($user_id){
         )
     );
     wp_remote_post($url, $args);
+    */
 
-    // Update author for all "classement" where uuid_user_r == vainkeurz_user_id
-    if (isset($_COOKIE["vainkeurz_user_id"])) {
-        $classements = new WP_Query(array(
-                'post_type'              => 'classement',
-                'posts_per_page'         => -1,
-                'fields'                 => 'ids',
-                'post_status'            => 'publish',
-                'ignore_sticky_posts'    => true,
-                'update_post_meta_cache' => false,
-                'no_found_rows'          => false,
-                'author__not_in'         => array($user_id),
-                'meta_query'             => array(
-                    array(
-                        'key' => 'uuid_user_r',
+
+    if (isset($_COOKIE["vainkeurz_user_id"]) && !empty($_COOKIE["vainkeurz_user_id"])) {
+
+        update_field('uuiduser_user', $_COOKIE["vainkeurz_user_id"], 'user_' . $user_id);
+
+        if ($user_id) {
+            // Update author for all "classement" where uuid_user_r == vainkeurz_user_id
+            $classements = new WP_Query(array(
+                    'post_type'              => 'classement',
+                    'posts_per_page'         => -1,
+                    'fields'                 => 'ids',
+                    'post_status'            => 'publish',
+                    'ignore_sticky_posts'    => true,
+                    'update_post_meta_cache' => false,
+                    'no_found_rows'          => false,
+                    'author__not_in'         => array($user_id),
+                    'meta_query'             => array(
+                        array(
+                            'key' => 'uuid_user_r',
+                            'value' => $_COOKIE["vainkeurz_user_id"],
+                            'compare' => '='
+                        ),
+                        array(
+                            'key' => 'id_tournoi_r',
+                            'value' => get_exclude_top(),
+                            'compare' => 'NOT IN'
+                        )
+                    )
+                ));
+
+            if ($classements->have_posts()) {
+                foreach ($classements->posts as $classement) {
+                    $arg = array(
+                        'ID'            => $classement,
+                        'post_author'   => $user_id,
+                    );
+                    wp_update_post( $arg );
+                }
+            }
+
+            // Update author for all "vainkeur" where uuid_user_r == vainkeurz_user_id
+            $vainkeur_entry = new WP_Query(array(
+                    'post_type'              => 'vainkeur',
+                    'posts_per_page'         => 1,
+                    'fields'                 => 'ids',
+                    'post_status'            => 'publish',
+                    'ignore_sticky_posts'    => true,
+                    'update_post_meta_cache' => false,
+                    'no_found_rows'          => false,
+                    'meta_query'             => array(array(
+                        'key' => 'uuid_user_vkrz',
                         'value' => $_COOKIE["vainkeurz_user_id"],
                         'compare' => '='
-                    ),
-                    array(
-                        'key' => 'id_tournoi_r',
-                        'value' => get_exclude_top(),
-                        'compare' => 'NOT IN'
-                    )
-                )
-            ));
+                    )),
+                ));
 
-        if ($classements->have_posts()) {
-            foreach ($classements->posts as $classement) {
-                $arg = array(
-                    'ID'            => $classement,
-                    'post_author'   => $user_id,
-                );
-                wp_update_post( $arg );
-            }
-        }
-    }
-
-    // Update author for all "vainkeur" where uuid_user_r == vainkeurz_user_id
-    if (isset($_COOKIE["vainkeurz_user_id"])) {
-        $vainkeur_entry = new WP_Query(array(
-                'post_type'              => 'vainkeur',
-                'posts_per_page'         => 1,
-                'fields'                 => 'ids',
-                'post_status'            => 'publish',
-                'ignore_sticky_posts'    => true,
-                'update_post_meta_cache' => false,
-                'no_found_rows'          => false,
-                'meta_query'             => array(array(
-                    'key' => 'uuid_user_vkrz',
-                    'value' => $_COOKIE["vainkeurz_user_id"],
-                    'compare' => '='
-                )),
-            ));
-
-        if ($vainkeur_entry->have_posts()) {
-            foreach ($vainkeur_entry->posts as $vainkeur_entry_result) {
-                $arg = array(
-                    'ID'            => $vainkeur_entry_result,
-                    'post_author'   => $user_id,
-                );
-                wp_update_post( $arg );
+            if ($vainkeur_entry->have_posts()) {
+                foreach ($vainkeur_entry->posts as $vainkeur_entry_result) {
+                    $arg = array(
+                        'ID'            => $vainkeur_entry_result,
+                        'post_author'   => $user_id,
+                    );
+                    wp_update_post( $arg );
+                }
             }
         }
     }
@@ -98,7 +109,7 @@ function new_vainkeur($user_id){
             dataLayer.push({
                 event: 'track_event',
                 event_name: 'signin',
-                user_id : <?= $user_id ?>,
+                user_id : "<?= $user_id ?>",
                 user_uuid : "<?= $uuiduser ?>",
                 utm : "<?= $utm ?>",
                 'event_score': 100

--- a/wp-content/themes/t-vkrz-3/user/sign-on.php
+++ b/wp-content/themes/t-vkrz-3/user/sign-on.php
@@ -1,6 +1,6 @@
 <?php
 /*
-    Template Name: Sign In
+    Template Name: Sign On
 */
 ?>
 <?php
@@ -36,7 +36,7 @@ if (is_user_logged_in()) {
                                 <div class="separateur separateur-1 mt-0"></div>
                                 <div class="classic-form">
                                     <h3>ou en mode classik</h3>
-                                    <?php echo do_shortcode('[wppb-register form_name="sign-in"]'); ?>
+                                    <?php echo do_shortcode('[wppb-register form_name="sign-on"]'); ?>
                                 </div>
                             </div>
 


### PR DESCRIPTION
- Add 2 update uuid : begin_t.php & new_vainkeur.php
- Modify condition in deal-uuiduser.php & new_vainkeur.php
- Update priority action "user_register" to 20 (default 10)
- Limit setcookie (in deal-uuiduser.php) only if not exist


![Capture d’écran 2021-10-30 à 19 24 41](https://user-images.githubusercontent.com/11027617/139543318-78183078-6360-4713-807d-fa7941663b23.png)

Loom (5 videos par ce que je suis en gratuit donc limité à 5minutes) : 
- https://www.loom.com/share/d7744897693245d081bf9c480600989c
- https://www.loom.com/share/b0c1f849d85449c2af12a11c31d91df3
- https://www.loom.com/share/fe09851c8e79441cbf51ce4761566660
- https://www.loom.com/share/22879255e08749d5be10cfa6827452e2 (bug reproduit)
- https://www.loom.com/share/3bfbdc87a2154acaa81b53a00645ba96 (bug compris et expliqué)

## Conclusion du bug : 
Cela vient du plugin Profile Builder. Il n'arrive pas à connecter l'utilisateur après l'inscription pensant que l'inscription a échoué alors qu'elle à bien réussi.
Le champs UUID n'est pas mis à jour car cela se fait uniquement si l'utilisateur est connecté (via la fonction deal_uuiduser()).

En ajoutant l'update du UUID dans la fonction new_vainkeur() (appelé après un user_register) cela pourra peut être régler le problème mais sans certitude puisque le bug n'est pas facilement reproductible.

La solution serait de pouvoir update le champs UUID directement via Profile Builder au moment de l'inscription. En créant un champs UUID qui remplacerait le champs ACF mais cela demande de modifier beaucoup de choses un peu partout puisqu'on ne pourrait plus utiliser get_field("uuid"). Autre soucis, dans la documentation de Profile Builder je ne trouve pas comment dire qu'un champs à comme valeur par défaut celle d'un cookie...Après ça peut se régler en trichant un peu (JS sur la page qui remplit l'input caché mais c'est une nouvelle source de bug possible et une augmentation de la complexité du système d'inscription).

Conclusion, si le problème devient trop important en terme de volume, il faut supprimer ce plugin et en utiliser un autre ou créer une inscription from scratch.

## A faire en cas de merge de la branche
- [ ] Appliquer le modèle de page "Sign On" à la page "Créer mon compte"
- [ ] Plugin profil builder : Renommer le formulaire d'inscription en "Sign On"